### PR TITLE
Fix to support the new IFrame API that Youtube recommends

### DIFF
--- a/YoutubePlayer.react.js
+++ b/YoutubePlayer.react.js
@@ -24,8 +24,8 @@ var loadAPI = (function() {
 
     status = 'loading';
     var script = document.createElement('script');
-    script.src = 'https://www.youtube.com/player_api?playerapiid=ytplayer';
-    script.onload = onload;
+    script.src = 'https://www.youtube.com/iframe_api';
+    onYouTubeIframeAPIReady = onload;
     var firstScriptTag = document.getElementsByTagName('script')[0];
     firstScriptTag.parentNode.insertBefore(script, firstScriptTag);
   };


### PR DESCRIPTION
The old javascript API is deprecated, and there are some changes. Ref issue: https://github.com/mdebbar/YoutubePlayer.react/issues/1
